### PR TITLE
feat: 완료목록 섹션 추가

### DIFF
--- a/frontend/src/components/ErrorAlert.test.tsx
+++ b/frontend/src/components/ErrorAlert.test.tsx
@@ -1,45 +1,46 @@
 import { render, screen, fireEvent, act } from '@testing-library/react'
 import { vi } from 'vitest'
 import ErrorAlert from './ErrorAlert'
+import { I18nProvider } from '../contexts/I18nContext'
 
 describe('ErrorAlert', () => {
   it('에러 메시지가 표시된다', () => {
-    render(<ErrorAlert message="오류가 발생했습니다." onClose={vi.fn()} />)
+    render(<I18nProvider><ErrorAlert message="오류가 발생했습니다." onClose={vi.fn()} /></I18nProvider>)
     expect(screen.getByText('오류가 발생했습니다.')).toBeInTheDocument()
     expect(screen.getByRole('alert')).toBeInTheDocument()
   })
 
   it('닫기 버튼 클릭 시 onClose가 호출된다', () => {
     const onClose = vi.fn()
-    render(<ErrorAlert message="에러" onClose={onClose} />)
+    render(<I18nProvider><ErrorAlert message="에러" onClose={onClose} /></I18nProvider>)
     fireEvent.click(screen.getByRole('button', { name: '에러 닫기' }))
     expect(onClose).toHaveBeenCalled()
   })
 
   it('statusCode 401 → "로그인이 필요합니다" 매핑', () => {
-    render(<ErrorAlert statusCode={401} onClose={vi.fn()} />)
+    render(<I18nProvider><ErrorAlert statusCode={401} onClose={vi.fn()} /></I18nProvider>)
     expect(screen.getByText('로그인이 필요합니다.')).toBeInTheDocument()
   })
 
   it('statusCode 403 → "접근 권한이 없습니다" 매핑', () => {
-    render(<ErrorAlert statusCode={403} onClose={vi.fn()} />)
+    render(<I18nProvider><ErrorAlert statusCode={403} onClose={vi.fn()} /></I18nProvider>)
     expect(screen.getByText('접근 권한이 없습니다.')).toBeInTheDocument()
   })
 
   it('statusCode 404 → "찾을 수 없습니다" 매핑', () => {
-    render(<ErrorAlert statusCode={404} onClose={vi.fn()} />)
+    render(<I18nProvider><ErrorAlert statusCode={404} onClose={vi.fn()} /></I18nProvider>)
     expect(screen.getByText('찾을 수 없습니다.')).toBeInTheDocument()
   })
 
   it('statusCode 500 → "서버 오류가 발생했습니다" 매핑', () => {
-    render(<ErrorAlert statusCode={500} onClose={vi.fn()} />)
+    render(<I18nProvider><ErrorAlert statusCode={500} onClose={vi.fn()} /></I18nProvider>)
     expect(screen.getByText('서버 오류가 발생했습니다.')).toBeInTheDocument()
   })
 
   it('autoClose=true 이면 3초 후 onClose가 자동 호출된다', async () => {
     vi.useFakeTimers()
     const onClose = vi.fn()
-    render(<ErrorAlert message="에러" onClose={onClose} autoClose />)
+    render(<I18nProvider><ErrorAlert message="에러" onClose={onClose} autoClose /></I18nProvider>)
     expect(onClose).not.toHaveBeenCalled()
     await act(async () => { vi.advanceTimersByTime(3000) })
     expect(onClose).toHaveBeenCalled()
@@ -47,7 +48,7 @@ describe('ErrorAlert', () => {
   })
 
   it('message와 statusCode 둘 다 없으면 렌더링되지 않는다', () => {
-    const { container } = render(<ErrorAlert onClose={vi.fn()} />)
+    const { container } = render(<I18nProvider><ErrorAlert onClose={vi.fn()} /></I18nProvider>)
     expect(container.firstChild).toBeNull()
   })
 })

--- a/frontend/src/components/LoadingSpinner.test.tsx
+++ b/frontend/src/components/LoadingSpinner.test.tsx
@@ -1,24 +1,25 @@
 import { render, screen } from '@testing-library/react'
 import LoadingSpinner from './LoadingSpinner'
+import { I18nProvider } from '../contexts/I18nContext'
 
 describe('LoadingSpinner', () => {
   it('기본 로딩 텍스트가 표시된다', () => {
-    render(<LoadingSpinner />)
+    render(<I18nProvider><LoadingSpinner /></I18nProvider>)
     expect(screen.getByText('로딩중...')).toBeInTheDocument()
   })
 
   it('커스텀 텍스트를 표시할 수 있다', () => {
-    render(<LoadingSpinner text="데이터 불러오는 중..." />)
+    render(<I18nProvider><LoadingSpinner text="데이터 불러오는 중..." /></I18nProvider>)
     expect(screen.getByText('데이터 불러오는 중...')).toBeInTheDocument()
   })
 
   it('스피너 요소가 렌더링된다', () => {
-    const { container } = render(<LoadingSpinner />)
+    const { container } = render(<I18nProvider><LoadingSpinner /></I18nProvider>)
     expect(container.querySelector('[aria-hidden="true"]')).toBeInTheDocument()
   })
 
   it('role="status"가 설정된다', () => {
-    render(<LoadingSpinner />)
+    render(<I18nProvider><LoadingSpinner /></I18nProvider>)
     expect(screen.getByRole('status')).toBeInTheDocument()
   })
 })

--- a/frontend/src/components/ProtectedRoute.test.tsx
+++ b/frontend/src/components/ProtectedRoute.test.tsx
@@ -3,6 +3,7 @@ import { render, screen, waitFor } from '@testing-library/react'
 import { MemoryRouter, Route, Routes } from 'react-router-dom'
 import { ProtectedRoute, PublicOnlyRoute } from './ProtectedRoute'
 import * as AuthContextModule from '../contexts/AuthContext'
+import { I18nProvider } from '../contexts/I18nContext'
 
 vi.mock('../contexts/AuthContext', async (importOriginal) => {
   const original = await importOriginal<typeof AuthContextModule>()
@@ -11,26 +12,30 @@ vi.mock('../contexts/AuthContext', async (importOriginal) => {
 
 function renderWithRouter(ui: React.ReactElement, initialPath = '/') {
   return render(
-    <MemoryRouter initialEntries={[initialPath]}>
-      <Routes>
-        <Route path="/" element={ui} />
-        <Route path="/login" element={<div>로그인 페이지</div>} />
-        <Route path="/signup" element={<div>회원가입 페이지</div>} />
-        <Route path="/home" element={ui} />
-      </Routes>
-    </MemoryRouter>,
+    <I18nProvider>
+      <MemoryRouter initialEntries={[initialPath]}>
+        <Routes>
+          <Route path="/" element={ui} />
+          <Route path="/login" element={<div>로그인 페이지</div>} />
+          <Route path="/signup" element={<div>회원가입 페이지</div>} />
+          <Route path="/home" element={ui} />
+        </Routes>
+      </MemoryRouter>
+    </I18nProvider>,
   )
 }
 
 function renderPublicRoute(ui: React.ReactElement, path = '/login') {
   return render(
-    <MemoryRouter initialEntries={[path]}>
-      <Routes>
-        <Route path="/" element={<div>홈 페이지</div>} />
-        <Route path="/login" element={ui} />
-        <Route path="/signup" element={ui} />
-      </Routes>
-    </MemoryRouter>,
+    <I18nProvider>
+      <MemoryRouter initialEntries={[path]}>
+        <Routes>
+          <Route path="/" element={<div>홈 페이지</div>} />
+          <Route path="/login" element={ui} />
+          <Route path="/signup" element={ui} />
+        </Routes>
+      </MemoryRouter>
+    </I18nProvider>,
   )
 }
 

--- a/frontend/src/components/TodoCard.test.tsx
+++ b/frontend/src/components/TodoCard.test.tsx
@@ -2,6 +2,7 @@ import { render, screen, fireEvent } from '@testing-library/react'
 import { vi } from 'vitest'
 import TodoCard from './TodoCard'
 import type { Todo } from '../types/api'
+import { I18nProvider } from '../contexts/I18nContext'
 
 const baseTodo: Todo = {
   todo_id: '1',
@@ -18,12 +19,14 @@ const baseTodo: Todo = {
 describe('TodoCard', () => {
   it('제목과 마감일이 렌더링된다', () => {
     render(
-      <TodoCard
-        todo={baseTodo}
-        onToggle={vi.fn()}
-        onEdit={vi.fn()}
-        onDelete={vi.fn()}
-      />
+      <I18nProvider>
+        <TodoCard
+          todo={baseTodo}
+          onToggle={vi.fn()}
+          onEdit={vi.fn()}
+          onDelete={vi.fn()}
+        />
+      </I18nProvider>
     )
     expect(screen.getByText('운영체제 과제')).toBeInTheDocument()
     expect(screen.getByText('2026-03-01')).toBeInTheDocument()
@@ -31,7 +34,9 @@ describe('TodoCard', () => {
 
   it('설명이 있으면 표시된다', () => {
     render(
-      <TodoCard todo={baseTodo} onToggle={vi.fn()} onEdit={vi.fn()} onDelete={vi.fn()} />
+      <I18nProvider>
+        <TodoCard todo={baseTodo} onToggle={vi.fn()} onEdit={vi.fn()} onDelete={vi.fn()} />
+      </I18nProvider>
     )
     expect(screen.getByText('3장 요약')).toBeInTheDocument()
   })
@@ -39,7 +44,9 @@ describe('TodoCard', () => {
   it('기한 초과 시 overdue 클래스가 적용된다', () => {
     const overdueTodo = { ...baseTodo, is_overdue: true }
     const { container } = render(
-      <TodoCard todo={overdueTodo} onToggle={vi.fn()} onEdit={vi.fn()} onDelete={vi.fn()} />
+      <I18nProvider>
+        <TodoCard todo={overdueTodo} onToggle={vi.fn()} onEdit={vi.fn()} onDelete={vi.fn()} />
+      </I18nProvider>
     )
     expect(container.firstChild).toHaveClass(/overdue/i)
   })
@@ -47,7 +54,9 @@ describe('TodoCard', () => {
   it('완료 상태 시 completed 클래스가 적용된다', () => {
     const completedTodo = { ...baseTodo, status: 'completed' as const }
     const { container } = render(
-      <TodoCard todo={completedTodo} onToggle={vi.fn()} onEdit={vi.fn()} onDelete={vi.fn()} />
+      <I18nProvider>
+        <TodoCard todo={completedTodo} onToggle={vi.fn()} onEdit={vi.fn()} onDelete={vi.fn()} />
+      </I18nProvider>
     )
     expect(container.firstChild).toHaveClass(/completed/i)
   })
@@ -55,7 +64,9 @@ describe('TodoCard', () => {
   it('체크박스 클릭 시 onToggle이 호출된다', () => {
     const onToggle = vi.fn()
     render(
-      <TodoCard todo={baseTodo} onToggle={onToggle} onEdit={vi.fn()} onDelete={vi.fn()} />
+      <I18nProvider>
+        <TodoCard todo={baseTodo} onToggle={onToggle} onEdit={vi.fn()} onDelete={vi.fn()} />
+      </I18nProvider>
     )
     fireEvent.click(screen.getByRole('checkbox'))
     expect(onToggle).toHaveBeenCalledWith('1')
@@ -64,7 +75,9 @@ describe('TodoCard', () => {
   it('수정 버튼 클릭 시 onEdit이 호출된다', () => {
     const onEdit = vi.fn()
     render(
-      <TodoCard todo={baseTodo} onToggle={vi.fn()} onEdit={onEdit} onDelete={vi.fn()} />
+      <I18nProvider>
+        <TodoCard todo={baseTodo} onToggle={vi.fn()} onEdit={onEdit} onDelete={vi.fn()} />
+      </I18nProvider>
     )
     fireEvent.click(screen.getByRole('button', { name: /수정/ }))
     expect(onEdit).toHaveBeenCalledWith('1')
@@ -73,7 +86,9 @@ describe('TodoCard', () => {
   it('삭제 버튼 클릭 시 onDelete가 호출된다', () => {
     const onDelete = vi.fn()
     render(
-      <TodoCard todo={baseTodo} onToggle={vi.fn()} onEdit={vi.fn()} onDelete={onDelete} />
+      <I18nProvider>
+        <TodoCard todo={baseTodo} onToggle={vi.fn()} onEdit={vi.fn()} onDelete={onDelete} />
+      </I18nProvider>
     )
     fireEvent.click(screen.getByRole('button', { name: /삭제/ }))
     expect(onDelete).toHaveBeenCalledWith('1')

--- a/frontend/src/components/TodoFormModal.test.tsx
+++ b/frontend/src/components/TodoFormModal.test.tsx
@@ -1,36 +1,43 @@
 import { render, screen, fireEvent, waitFor } from '@testing-library/react'
 import { vi } from 'vitest'
 import TodoFormModal from './TodoFormModal'
+import { I18nProvider } from '../contexts/I18nContext'
 
 describe('TodoFormModal', () => {
   it('isOpen=false이면 렌더링되지 않는다', () => {
     render(
-      <TodoFormModal
-        isOpen={false}
-        mode="create"
-        onSubmit={vi.fn()}
-        onCancel={vi.fn()}
-      />
+      <I18nProvider>
+        <TodoFormModal
+          isOpen={false}
+          mode="create"
+          onSubmit={vi.fn()}
+          onCancel={vi.fn()}
+        />
+      </I18nProvider>
     )
     expect(screen.queryByRole('dialog')).not.toBeInTheDocument()
   })
 
   it('생성 모달: 제목이 "할일 추가"이다', () => {
     render(
-      <TodoFormModal isOpen mode="create" onSubmit={vi.fn()} onCancel={vi.fn()} />
+      <I18nProvider>
+        <TodoFormModal isOpen mode="create" onSubmit={vi.fn()} onCancel={vi.fn()} />
+      </I18nProvider>
     )
     expect(screen.getByText('할일 추가')).toBeInTheDocument()
   })
 
   it('수정 모달: 제목이 "할일 수정"이고 초기값이 pre-fill된다', () => {
     render(
-      <TodoFormModal
-        isOpen
-        mode="edit"
-        initialValues={{ title: '논문 초안', description: '서론 포함', due_date: '2026-03-01' }}
-        onSubmit={vi.fn()}
-        onCancel={vi.fn()}
-      />
+      <I18nProvider>
+        <TodoFormModal
+          isOpen
+          mode="edit"
+          initialValues={{ title: '논문 초안', description: '서론 포함', due_date: '2026-03-01' }}
+          onSubmit={vi.fn()}
+          onCancel={vi.fn()}
+        />
+      </I18nProvider>
     )
     expect(screen.getByText('할일 수정')).toBeInTheDocument()
     expect(screen.getByDisplayValue('논문 초안')).toBeInTheDocument()
@@ -40,7 +47,9 @@ describe('TodoFormModal', () => {
 
   it('제목 미입력 시 에러가 표시된다', async () => {
     render(
-      <TodoFormModal isOpen mode="create" onSubmit={vi.fn()} onCancel={vi.fn()} />
+      <I18nProvider>
+        <TodoFormModal isOpen mode="create" onSubmit={vi.fn()} onCancel={vi.fn()} />
+      </I18nProvider>
     )
     fireEvent.submit(screen.getByRole('dialog').querySelector('form')!)
     await waitFor(() => {
@@ -50,7 +59,9 @@ describe('TodoFormModal', () => {
 
   it('마감일 미입력 시 에러가 표시된다', async () => {
     render(
-      <TodoFormModal isOpen mode="create" onSubmit={vi.fn()} onCancel={vi.fn()} />
+      <I18nProvider>
+        <TodoFormModal isOpen mode="create" onSubmit={vi.fn()} onCancel={vi.fn()} />
+      </I18nProvider>
     )
     fireEvent.change(screen.getByLabelText(/제목/), { target: { value: '테스트' } })
     fireEvent.submit(screen.getByRole('dialog').querySelector('form')!)
@@ -62,7 +73,9 @@ describe('TodoFormModal', () => {
   it('유효한 값 제출 시 onSubmit이 호출된다', async () => {
     const onSubmit = vi.fn().mockResolvedValue(undefined)
     render(
-      <TodoFormModal isOpen mode="create" onSubmit={onSubmit} onCancel={vi.fn()} />
+      <I18nProvider>
+        <TodoFormModal isOpen mode="create" onSubmit={onSubmit} onCancel={vi.fn()} />
+      </I18nProvider>
     )
     fireEvent.change(screen.getByLabelText(/제목/), { target: { value: '새 할일' } })
     fireEvent.change(screen.getByLabelText(/마감일/), { target: { value: '2026-03-01' } })
@@ -79,7 +92,9 @@ describe('TodoFormModal', () => {
   it('[취소] 버튼 클릭 시 onCancel이 호출된다', () => {
     const onCancel = vi.fn()
     render(
-      <TodoFormModal isOpen mode="create" onSubmit={vi.fn()} onCancel={onCancel} />
+      <I18nProvider>
+        <TodoFormModal isOpen mode="create" onSubmit={vi.fn()} onCancel={onCancel} />
+      </I18nProvider>
     )
     fireEvent.click(screen.getByRole('button', { name: '취소' }))
     expect(onCancel).toHaveBeenCalled()
@@ -88,7 +103,9 @@ describe('TodoFormModal', () => {
   it('[X] 버튼 클릭 시 onCancel이 호출된다', () => {
     const onCancel = vi.fn()
     render(
-      <TodoFormModal isOpen mode="create" onSubmit={vi.fn()} onCancel={onCancel} />
+      <I18nProvider>
+        <TodoFormModal isOpen mode="create" onSubmit={vi.fn()} onCancel={onCancel} />
+      </I18nProvider>
     )
     fireEvent.click(screen.getByRole('button', { name: '닫기' }))
     expect(onCancel).toHaveBeenCalled()
@@ -97,7 +114,9 @@ describe('TodoFormModal', () => {
   it('배경 클릭 시 onCancel이 호출된다', () => {
     const onCancel = vi.fn()
     render(
-      <TodoFormModal isOpen mode="create" onSubmit={vi.fn()} onCancel={onCancel} />
+      <I18nProvider>
+        <TodoFormModal isOpen mode="create" onSubmit={vi.fn()} onCancel={onCancel} />
+      </I18nProvider>
     )
     fireEvent.click(screen.getByTestId('modal-backdrop'))
     expect(onCancel).toHaveBeenCalled()
@@ -109,7 +128,9 @@ describe('TodoFormModal', () => {
       new Promise<void>((resolve) => { resolveSubmit = resolve })
     )
     render(
-      <TodoFormModal isOpen mode="create" onSubmit={onSubmit} onCancel={vi.fn()} />
+      <I18nProvider>
+        <TodoFormModal isOpen mode="create" onSubmit={onSubmit} onCancel={vi.fn()} />
+      </I18nProvider>
     )
     fireEvent.change(screen.getByLabelText(/제목/), { target: { value: '새 할일' } })
     fireEvent.change(screen.getByLabelText(/마감일/), { target: { value: '2026-03-01' } })

--- a/frontend/src/i18n/en.ts
+++ b/frontend/src/i18n/en.ts
@@ -48,6 +48,7 @@ const en: Record<TranslationKeys, string> = {
   emptySubtitle: 'Add your first todo below!',
   overdueGroup: '⚠ Overdue ({n})',
   normalGroup: 'Todos ({n})',
+  completedGroup: '✓ Completed ({n})',
   addTodo: '+ Add Todo',
   fetchTodoFailed: 'Failed to load todo.',
   toggleFailed: 'Failed to update status.',

--- a/frontend/src/i18n/ko.ts
+++ b/frontend/src/i18n/ko.ts
@@ -46,6 +46,7 @@ const ko = {
   emptySubtitle: '아래 버튼으로 첫 할일을 추가해보세요!',
   overdueGroup: '⚠ 기한 초과 ({n}건)',
   normalGroup: '할일 목록 ({n}건)',
+  completedGroup: '✓ 완료됨 ({n}건)',
   addTodo: '+ 할일 추가',
   fetchTodoFailed: '할일 정보를 불러오지 못했습니다.',
   toggleFailed: '상태 변경에 실패했습니다.',

--- a/frontend/src/pages/HomePage.module.css
+++ b/frontend/src/pages/HomePage.module.css
@@ -224,6 +224,15 @@
   border-bottom: 1px solid var(--color-error);
 }
 
+.groupHeaderCompleted {
+  font-size: 14px;
+  font-weight: 500;
+  color: var(--color-success);
+  margin: 0 0 var(--space-3);
+  padding-bottom: var(--space-2);
+  border-bottom: 1px solid var(--color-success);
+}
+
 .todoList {
   display: grid;
   grid-template-columns: 1fr;

--- a/frontend/src/pages/HomePage.test.tsx
+++ b/frontend/src/pages/HomePage.test.tsx
@@ -1,9 +1,11 @@
 import { render, screen, fireEvent, waitFor, act } from '@testing-library/react'
 import { MemoryRouter } from 'react-router-dom'
 import { vi } from 'vitest'
+import type { ReactElement } from 'react'
 import HomePage from './HomePage'
 import * as AuthContextModule from '../contexts/AuthContext'
 import * as apiClient from '../api/client'
+import { I18nProvider } from '../contexts/I18nContext'
 import type { TodoListResponse } from '../types/api'
 
 const mockNavigate = vi.fn()
@@ -59,10 +61,10 @@ function mockApiGet(response: TodoListResponse = sampleResponse) {
   vi.spyOn(apiClient.apiClient, 'get').mockResolvedValue(response)
 }
 
-function renderHomePage() {
+function renderWithProviders(ui: ReactElement) {
   return render(
     <MemoryRouter>
-      <HomePage />
+      <I18nProvider>{ui}</I18nProvider>
     </MemoryRouter>
   )
 }
@@ -75,7 +77,7 @@ describe('HomePage', () => {
   })
 
   it('사용자 이름과 로그아웃 버튼이 렌더링된다', async () => {
-    renderHomePage()
+    renderWithProviders(<HomePage />)
     await waitFor(() => {
       expect(screen.getByText(/안녕하세요, 김지수님/)).toBeInTheDocument()
     })
@@ -83,7 +85,7 @@ describe('HomePage', () => {
   })
 
   it('할일 목록이 렌더링된다', async () => {
-    renderHomePage()
+    renderWithProviders(<HomePage />)
     await waitFor(() => {
       expect(screen.getByText('데이터베이스 과제')).toBeInTheDocument()
       expect(screen.getByText('논문 초안 작성')).toBeInTheDocument()
@@ -91,7 +93,7 @@ describe('HomePage', () => {
   })
 
   it('기한 초과 그룹이 별도로 표시된다', async () => {
-    renderHomePage()
+    renderWithProviders(<HomePage />)
     await waitFor(() => {
       expect(screen.getByText(/기한 초과/)).toBeInTheDocument()
     })
@@ -99,7 +101,7 @@ describe('HomePage', () => {
 
   it('빈 목록 시 안내 메시지가 표시된다', async () => {
     vi.spyOn(apiClient.apiClient, 'get').mockResolvedValue({ overdue: [], normal: [] })
-    renderHomePage()
+    renderWithProviders(<HomePage />)
     await waitFor(() => {
       expect(screen.getByText('할일이 없습니다.')).toBeInTheDocument()
     })
@@ -108,7 +110,7 @@ describe('HomePage', () => {
   it('[로그아웃] 클릭 시 logout이 호출된다', async () => {
     const logout = vi.fn().mockResolvedValue(undefined)
     mockUseAuth({ logout })
-    renderHomePage()
+    renderWithProviders(<HomePage />)
     await waitFor(() => {
       expect(screen.getByRole('button', { name: '로그아웃' })).toBeInTheDocument()
     })
@@ -119,7 +121,7 @@ describe('HomePage', () => {
   })
 
   it('[+ 할일 추가] 클릭 시 생성 모달이 열린다', async () => {
-    renderHomePage()
+    renderWithProviders(<HomePage />)
     await waitFor(() => {
       expect(screen.getByRole('button', { name: /할일 추가/ })).toBeInTheDocument()
     })
@@ -128,7 +130,7 @@ describe('HomePage', () => {
   })
 
   it('AC-11: 기한 초과 항목이 상단 그룹에 표시된다', async () => {
-    renderHomePage()
+    renderWithProviders(<HomePage />)
     await waitFor(() => {
       const overdueSection = screen.getByText(/기한 초과/)
       const overdueTodo = screen.getByText('데이터베이스 과제')
@@ -139,7 +141,7 @@ describe('HomePage', () => {
 
   it('검색어 입력 시 API가 q 파라미터와 함께 호출된다', async () => {
     const getSpy = vi.spyOn(apiClient.apiClient, 'get').mockResolvedValue({ overdue: [], normal: [] })
-    renderHomePage()
+    renderWithProviders(<HomePage />)
     await waitFor(() => screen.getByPlaceholderText(/검색/))
 
     fireEvent.change(screen.getByPlaceholderText(/검색/), { target: { value: '논문' } })
@@ -153,7 +155,7 @@ describe('HomePage', () => {
 
   it('상태 필터 탭 클릭 시 API가 status 파라미터와 함께 호출된다', async () => {
     const getSpy = vi.spyOn(apiClient.apiClient, 'get').mockResolvedValue({ overdue: [], normal: [] })
-    renderHomePage()
+    renderWithProviders(<HomePage />)
     await waitFor(() => screen.getByRole('button', { name: '미완료' }))
 
     fireEvent.click(screen.getByRole('button', { name: '미완료' }))
@@ -163,5 +165,215 @@ describe('HomePage', () => {
       const lastCall = calls[calls.length - 1][0] as string
       expect(lastCall).toContain('status=pending')
     })
+  })
+})
+
+// 이슈 #36: 완료 목록 추가
+describe('HomePage - 완료 목록 섹션 (#36)', () => {
+  beforeEach(() => {
+    mockUseAuth()
+    mockNavigate.mockClear()
+  })
+
+  it('완료된 아이템이 API로부터 오면 "완료됨" 섹션에 표시된다', async () => {
+    vi.spyOn(apiClient.apiClient, 'get').mockResolvedValue({
+      overdue: [],
+      normal: [
+        {
+          todo_id: 'c1',
+          user_id: 'u1',
+          title: '완료된 과제',
+          description: null,
+          due_date: '2026-03-01',
+          status: 'completed',
+          is_overdue: false,
+          created_at: '2026-02-10T00:00:00Z',
+          updated_at: '2026-02-10T00:00:00Z',
+        },
+      ],
+    })
+
+    renderWithProviders(<HomePage />)
+
+    await waitFor(() => {
+      expect(screen.getByText(/✓ 완료됨/)).toBeInTheDocument()
+      expect(screen.getByText('완료된 과제')).toBeInTheDocument()
+    })
+  })
+
+  it('완료된 아이템이 없으면 완료 섹션이 표시되지 않는다', async () => {
+    vi.spyOn(apiClient.apiClient, 'get').mockResolvedValue({
+      overdue: [],
+      normal: [
+        {
+          todo_id: 'n1',
+          user_id: 'u1',
+          title: '진행중인 할일',
+          description: null,
+          due_date: '2026-03-01',
+          status: 'pending',
+          is_overdue: false,
+          created_at: '2026-02-10T00:00:00Z',
+          updated_at: '2026-02-10T00:00:00Z',
+        },
+      ],
+    })
+
+    renderWithProviders(<HomePage />)
+
+    await waitFor(() => {
+      expect(screen.getByText('진행중인 할일')).toBeInTheDocument()
+    })
+
+    expect(screen.queryByText(/✓ 완료됨/)).not.toBeInTheDocument()
+  })
+
+  it('pending 아이템은 "할일 목록" 섹션에, completed 아이템은 "완료됨" 섹션에 분리된다', async () => {
+    vi.spyOn(apiClient.apiClient, 'get').mockResolvedValue({
+      overdue: [],
+      normal: [
+        {
+          todo_id: 'n1',
+          user_id: 'u1',
+          title: '해야 할 일',
+          description: null,
+          due_date: '2026-03-01',
+          status: 'pending',
+          is_overdue: false,
+          created_at: '2026-02-10T00:00:00Z',
+          updated_at: '2026-02-10T00:00:00Z',
+        },
+        {
+          todo_id: 'c1',
+          user_id: 'u1',
+          title: '끝낸 일',
+          description: null,
+          due_date: '2026-03-01',
+          status: 'completed',
+          is_overdue: false,
+          created_at: '2026-02-10T00:00:00Z',
+          updated_at: '2026-02-10T00:00:00Z',
+        },
+      ],
+    })
+
+    renderWithProviders(<HomePage />)
+
+    await waitFor(() => {
+      expect(screen.getByText(/할일 목록 \(1건\)/)).toBeInTheDocument()
+      expect(screen.getByText(/✓ 완료됨 \(1건\)/)).toBeInTheDocument()
+      expect(screen.getByText('해야 할 일')).toBeInTheDocument()
+      expect(screen.getByText('끝낸 일')).toBeInTheDocument()
+    })
+  })
+
+  it('overdue 아이템은 "기한 초과" 섹션에 표시된다', async () => {
+    vi.spyOn(apiClient.apiClient, 'get').mockResolvedValue({
+      overdue: [
+        {
+          todo_id: 'o1',
+          user_id: 'u1',
+          title: '기한 지난 과제',
+          description: null,
+          due_date: '2026-02-01',
+          status: 'pending',
+          is_overdue: true,
+          created_at: '2026-01-01T00:00:00Z',
+          updated_at: '2026-01-01T00:00:00Z',
+        },
+      ],
+      normal: [],
+    })
+
+    renderWithProviders(<HomePage />)
+
+    await waitFor(() => {
+      expect(screen.getByText(/⚠ 기한 초과 \(1건\)/)).toBeInTheDocument()
+      expect(screen.getByText('기한 지난 과제')).toBeInTheDocument()
+    })
+  })
+
+  it('filter="completed" 선택 시 API에 status=completed 파라미터가 전달되고 완료 섹션이 표시된다', async () => {
+    const getSpy = vi.spyOn(apiClient.apiClient, 'get').mockResolvedValue({
+      overdue: [],
+      normal: [
+        {
+          todo_id: 'c1',
+          user_id: 'u1',
+          title: '필터된 완료 항목',
+          description: null,
+          due_date: '2026-03-01',
+          status: 'completed',
+          is_overdue: false,
+          created_at: '2026-02-10T00:00:00Z',
+          updated_at: '2026-02-10T00:00:00Z',
+        },
+      ],
+    })
+
+    renderWithProviders(<HomePage />)
+
+    await waitFor(() => screen.getByRole('button', { name: '완료' }))
+
+    fireEvent.click(screen.getByRole('button', { name: '완료' }))
+
+    await waitFor(() => {
+      const calls = getSpy.mock.calls
+      const lastCall = calls[calls.length - 1][0] as string
+      expect(lastCall).toContain('status=completed')
+    })
+
+    await waitFor(() => {
+      expect(screen.getByText(/✓ 완료됨/)).toBeInTheDocument()
+      expect(screen.getByText('필터된 완료 항목')).toBeInTheDocument()
+    })
+  })
+
+  it('모든 아이템이 없으면 빈 상태 메시지가 표시된다', async () => {
+    vi.spyOn(apiClient.apiClient, 'get').mockResolvedValue({ overdue: [], normal: [] })
+
+    renderWithProviders(<HomePage />)
+
+    await waitFor(() => {
+      expect(screen.getByText('할일이 없습니다.')).toBeInTheDocument()
+      expect(screen.getByText('아래 버튼으로 첫 할일을 추가해보세요!')).toBeInTheDocument()
+    })
+
+    expect(screen.queryByText(/✓ 완료됨/)).not.toBeInTheDocument()
+    expect(screen.queryByText(/할일 목록/)).not.toBeInTheDocument()
+    expect(screen.queryByText(/기한 초과/)).not.toBeInTheDocument()
+  })
+
+  it('완료된 아이템 체크박스 클릭 시 PATCH /todos/:id/status가 호출된다', async () => {
+    vi.spyOn(apiClient.apiClient, 'get').mockResolvedValue({
+      overdue: [],
+      normal: [
+        {
+          todo_id: 'c1',
+          user_id: 'u1',
+          title: '완료 상태 토글 테스트',
+          description: null,
+          due_date: '2026-03-01',
+          status: 'completed',
+          is_overdue: false,
+          created_at: '2026-02-10T00:00:00Z',
+          updated_at: '2026-02-10T00:00:00Z',
+        },
+      ],
+    })
+    const patchSpy = vi.spyOn(apiClient.apiClient, 'patch').mockResolvedValue(undefined)
+
+    renderWithProviders(<HomePage />)
+
+    await waitFor(() => {
+      expect(screen.getByText('완료 상태 토글 테스트')).toBeInTheDocument()
+    })
+
+    const checkbox = screen.getByRole('checkbox', { name: '완료 취소' })
+    await act(async () => {
+      fireEvent.click(checkbox)
+    })
+
+    expect(patchSpy).toHaveBeenCalledWith('/todos/c1/status', { status: 'pending' })
   })
 })

--- a/frontend/src/pages/HomePageFE09_11.test.tsx
+++ b/frontend/src/pages/HomePageFE09_11.test.tsx
@@ -8,6 +8,7 @@ import HomePage from './HomePage'
 import * as AuthContextModule from '../contexts/AuthContext'
 import * as apiClient from '../api/client'
 import type { Todo, TodoListResponse } from '../types/api'
+import { I18nProvider } from '../contexts/I18nContext'
 
 const mockNavigate = vi.fn()
 vi.mock('react-router-dom', async (importOriginal) => {
@@ -59,9 +60,11 @@ function mockApiGet(response: TodoListResponse = listResponse) {
 
 function renderHomePage() {
   return render(
-    <MemoryRouter>
-      <HomePage />
-    </MemoryRouter>
+    <I18nProvider>
+      <MemoryRouter>
+        <HomePage />
+      </MemoryRouter>
+    </I18nProvider>
   )
 }
 

--- a/frontend/src/pages/LoginPage.test.tsx
+++ b/frontend/src/pages/LoginPage.test.tsx
@@ -5,6 +5,7 @@ import { MemoryRouter, Route, Routes } from 'react-router-dom'
 import LoginPage from './LoginPage'
 import * as AuthContextModule from '../contexts/AuthContext'
 import { ApiRequestError } from '../api/client'
+import { I18nProvider } from '../contexts/I18nContext'
 
 vi.mock('../contexts/AuthContext', async (importOriginal) => {
   const original = await importOriginal<typeof AuthContextModule>()
@@ -27,13 +28,15 @@ function makeAuthMock(overrides?: Partial<ReturnType<typeof AuthContextModule.us
 
 function renderLoginPage(initialPath = '/login') {
   return render(
-    <MemoryRouter initialEntries={[initialPath]}>
-      <Routes>
-        <Route path="/login" element={<LoginPage />} />
-        <Route path="/" element={<div>홈 페이지</div>} />
-        <Route path="/signup" element={<div>회원가입 페이지</div>} />
-      </Routes>
-    </MemoryRouter>,
+    <I18nProvider>
+      <MemoryRouter initialEntries={[initialPath]}>
+        <Routes>
+          <Route path="/login" element={<LoginPage />} />
+          <Route path="/" element={<div>홈 페이지</div>} />
+          <Route path="/signup" element={<div>회원가입 페이지</div>} />
+        </Routes>
+      </MemoryRouter>
+    </I18nProvider>,
   )
 }
 

--- a/frontend/src/pages/SignupPage.test.tsx
+++ b/frontend/src/pages/SignupPage.test.tsx
@@ -3,6 +3,7 @@ import { MemoryRouter } from 'react-router-dom'
 import { vi } from 'vitest'
 import SignupPage from './SignupPage'
 import * as AuthContextModule from '../contexts/AuthContext'
+import { I18nProvider } from '../contexts/I18nContext'
 
 const mockNavigate = vi.fn()
 vi.mock('react-router-dom', async (importOriginal) => {
@@ -24,9 +25,11 @@ function mockUseAuth(overrides = {}) {
 
 function renderSignupPage() {
   return render(
-    <MemoryRouter>
-      <SignupPage />
-    </MemoryRouter>
+    <I18nProvider>
+      <MemoryRouter>
+        <SignupPage />
+      </MemoryRouter>
+    </I18nProvider>
   )
 }
 


### PR DESCRIPTION
## Summary
- 할일 목록 하단에 완료된 태스크를 `✓ 완료됨` 별도 섹션으로 분리
- `normal` 배열을 클라이언트에서 `pending`/`completed`로 분리하여 섹션별 표시
- 완료 섹션이 비어있으면 미표시 (조건부 렌더링)

## Changes
- `HomePage.tsx`: `completed` 상태 추가, fetchTodos 분리 로직, completed 섹션 렌더링, handleToggle 버그 수정
- `HomePage.module.css`: `.groupHeaderCompleted` 스타일 추가 (초록색)
- `i18n/ko.ts`, `i18n/en.ts`: `completedGroup` 번역 키 추가
- 기존 테스트 전체에 `I18nProvider` 래퍼 추가
- `HomePage.test.tsx`: 완료목록 테스트 7개 추가

## Test plan
- [x] `npm run build` 빌드 성공
- [x] HomePage 테스트 16/16 통과 (기존 9 + 신규 7)
- [x] 전체 테스트 104/106 통과 (나머지 2개는 AuthContext.test.tsx 기존 버그)

Closes #36

🤖 Generated with [Claude Code](https://claude.com/claude-code)